### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides tools for verifiable credential operations using the HiveAuth ecosystem. This server exposes HiveAuth's credential management capabilities to LLM applications via the standardized MCP interface.
 
+<a href="https://glama.ai/mcp/servers/@AlyssonM/hiveauth-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@AlyssonM/hiveauth-mcp/badge" alt="HiveAuth Server MCP server" />
+</a>
+
 ## Overview
 
 The HiveAuth MCP Server provides these tools to LLM applications:


### PR DESCRIPTION
This PR adds a badge for the [HiveAuth MCP Server](https://glama.ai/mcp/servers/@AlyssonM/hiveauth-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@AlyssonM/hiveauth-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@AlyssonM/hiveauth-mcp/badge" alt="HiveAuth Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.